### PR TITLE
Backoff support

### DIFF
--- a/util.go
+++ b/util.go
@@ -1,0 +1,11 @@
+package wait
+
+import (
+	"math/rand"
+	"time"
+)
+
+func jitterDuration(duration time.Duration, jitterPercentage int) time.Duration {
+	maxTimeJitter := int64(duration) / int64(jitterPercentage)
+	return time.Duration(int64(duration) + rand.Int63n(maxTimeJitter*2) - maxTimeJitter)
+}

--- a/wait_test.go
+++ b/wait_test.go
@@ -9,13 +9,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUntil(t *testing.T){
-	t.Run("wait for 3 seconds", func (t *testing.T){
+func TestUntil(t *testing.T) {
+	t.Run("wait for 3 seconds", func(t *testing.T) {
 		value := false
 		mu := sync.Mutex{}
 
-		go func ()  {
-			<- time.After(time.Second*3)
+		go func() {
+			<-time.After(time.Second * 3)
 			mu.Lock()
 			defer mu.Unlock()
 			value = true
@@ -27,24 +27,20 @@ func TestUntil(t *testing.T){
 			return value, nil
 		})
 
-		if err != nil {
-			t.Error(err)
-			return
-		}
+		assert.Nil(t, err)
 	})
 
-	t.Run("jitter should produce non-repeating interval check times", func (t *testing.T)  {
-		options := &Options{
-			timeout: time.Minute,
-			interval: time.Millisecond*500,
-			jitter: 10, //10% of jitter in this case
+	t.Run("jitter should produce non-repeating interval check times", func(t *testing.T) {
+		options := &UntilOptions{
+			interval: time.Millisecond * 500,
+			jitter:   10, //10% of jitter in this case
 		}
 
 		value := false
 		mu := sync.Mutex{}
 
-		go func ()  {
-			<- time.After(time.Second*5)
+		go func() {
+			<-time.After(time.Second * 5)
 			mu.Lock()
 			defer mu.Unlock()
 			value = true
@@ -68,17 +64,8 @@ func TestUntil(t *testing.T){
 			}
 			checkIntervals[i-1] = checkTimes[i].Sub(checkTimes[i-1])
 		}
-
-		expectedJitterOffset := time.Duration(int64(options.interval)/int64(options.jitter))
-
-		expectedMinInterval := options.interval - expectedJitterOffset
-		expectedMaxInterval := options.interval + expectedJitterOffset
 		didAnyIntervalJitter := false
-
 		for _, interval := range checkIntervals {
-			assert.GreaterOrEqual(t, interval, expectedMinInterval)
-			assert.LessOrEqual(t, interval, expectedMaxInterval)
-		
 			if interval != options.interval {
 				didAnyIntervalJitter = true
 			}
@@ -88,23 +75,32 @@ func TestUntil(t *testing.T){
 	})
 
 	t.Run("should timeout", func(t *testing.T) {
-		options := &Options{
-			timeout: time.Second*2,
-			interval: defaultOptions.interval,
+		options := &UntilOptions{
+			interval: defaultUntilOptions.interval,
 		}
 		returnFunc := func() (bool, error) {
 			return false, nil
 		}
 
-		err := Until(context.Background(), returnFunc, options);
-		if err == nil {
-			t.Fail()
-			return
-		}
+		// we use context to 
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+		defer cancel()
 
-		if err != ctxErr {
-			t.Errorf("not expected timeout err: %v", err)
-			return
-		}
+		err := Until(ctx, returnFunc, options)
+		assert.NotNil(t, err)
+		assert.ErrorIs(t, err, canceledErr)
 	})
+}
+
+func TestJitterDuration(t *testing.T) {
+	d := time.Second*100
+	jitter := 50
+	offset := time.Duration(int64(d)/int64(jitter))
+	expectedMinInterval := d-offset
+	expectedMaxInterval := d+offset
+
+	for i:=1;i<1000;i++{
+		jd := jitterDuration(d, jitter)
+		assert.True(t, expectedMinInterval <= jd && jd <= expectedMaxInterval)
+	}
 }

--- a/wait_test.go
+++ b/wait_test.go
@@ -9,8 +9,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func calcCheckTimesDelta(checkTimes []time.Time) []time.Duration {
+	checkDurations := []time.Duration{}
+	for i := range checkTimes {
+		if i == 0 {
+			continue
+		}
+		checkDurations = append(checkDurations, checkTimes[i].Sub(checkTimes[i-1]))
+	}
+	return checkDurations
+}
+
 func TestUntil(t *testing.T) {
+	t.Parallel()
+
 	t.Run("wait for 3 seconds", func(t *testing.T) {
+		t.Parallel()
 		value := false
 		mu := sync.Mutex{}
 
@@ -31,6 +45,7 @@ func TestUntil(t *testing.T) {
 	})
 
 	t.Run("jitter should produce non-repeating interval check times", func(t *testing.T) {
+		t.Parallel()
 		options := &UntilOptions{
 			interval: time.Millisecond * 500,
 			jitter:   10, //10% of jitter in this case
@@ -57,13 +72,7 @@ func TestUntil(t *testing.T) {
 		err := Until(context.Background(), returnFunc, options)
 		assert.Nil(t, err)
 
-		checkIntervals := make([]time.Duration, len(checkTimes)-1)
-		for i := range checkTimes {
-			if i == 0 {
-				continue
-			}
-			checkIntervals[i-1] = checkTimes[i].Sub(checkTimes[i-1])
-		}
+		checkIntervals := calcCheckTimesDelta(checkTimes)
 		didAnyIntervalJitter := false
 		for _, interval := range checkIntervals {
 			if interval != options.interval {
@@ -75,6 +84,7 @@ func TestUntil(t *testing.T) {
 	})
 
 	t.Run("should timeout", func(t *testing.T) {
+		t.Parallel()
 		options := &UntilOptions{
 			interval: defaultUntilOptions.interval,
 		}
@@ -92,7 +102,87 @@ func TestUntil(t *testing.T) {
 	})
 }
 
+func TestBackoff(t *testing.T){
+	t.Parallel()
+
+	t.Run("should backoff interval of checks", func (t *testing.T)  {
+		t.Parallel()
+		checkTimes := []time.Time{}
+		counter := 0
+		err := Backoff(context.Background(), func() (bool, error) {
+			checkTimes = append(checkTimes, time.Now())
+			counter++
+			if counter == 10 {
+				return true, nil
+			}
+			return false, nil
+		})
+		assert.Nil(t, err)
+
+		checkDurations := calcCheckTimesDelta(checkTimes)
+		for i := range checkDurations {
+			if i == 0 {
+				continue
+			}
+			assert.Greater(t, checkDurations[i], checkDurations[i-1])
+		}
+	})
+
+	t.Run("should be cancelable", func (t *testing.T)  {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+
+		go func (){
+			<- time.After(time.Second*3)
+			cancel()
+		}()
+
+		err := Backoff(ctx, func() (bool, error) {
+			return false, nil
+		})
+		assert.NotNil(t, err)
+		assert.ErrorIs(t, err, canceledErr)
+	})
+
+	t.Run("should be able to timeout", func (t *testing.T)  {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+		defer cancel()
+		err := Backoff(ctx, func() (bool, error) {
+			return false, nil
+		})
+		assert.NotNil(t, err)
+		assert.ErrorIs(t, err, canceledErr)
+	})
+
+	t.Run("should not pass limit", func (t *testing.T)  {
+		t.Parallel()
+		expectedMaxInterval := time.Millisecond*200
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+		defer cancel()
+		checkTimes := []time.Time{}
+
+		err := Backoff(ctx, func () (bool, error) {
+			checkTimes = append(checkTimes, time.Now())
+			return false, nil
+		}, &BackoffOptions{
+			baselineDuration: time.Millisecond*100,
+			limit: expectedMaxInterval,
+		})
+
+		assert.NotNil(t, err)
+		assert.ErrorIs(t, err, canceledErr)
+
+		intervals := calcCheckTimesDelta(checkTimes)
+		for _, d := range intervals {
+			assert.LessOrEqual(t, d, expectedMaxInterval)
+		}
+	})
+}
+
 func TestJitterDuration(t *testing.T) {
+	t.Parallel()
 	d := time.Second*100
 	jitter := 50
 	offset := time.Duration(int64(d)/int64(jitter))


### PR DESCRIPTION
## Background
I started working on some network features with `http.Server` and while going over the `Shutdown` function I noticed
some cool jitter & backoff related logic so I wanted to also implement it in `go-wait`

## New stuff
Ability to perform backoff wait operations for low CPU overhead with a Baseline, Limit & Multiplier.
Jitter is also supported in this capability already :)